### PR TITLE
Add missing include directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(BUILD_SHARED_LIBS "Enable shared library construction.")
 set(MMAPTWO_PLUS_OS CACHE STRING "Target memory mapping API.")
 
 add_library(mmaptwo_plus "mmaptwo.cpp" "mmaptwo.hpp")
-target_compile_features(mmaptwo_plus PRIVATE
+target_compile_features(mmaptwo_plus PUBLIC
     cxx_override cxx_nullptr cxx_constexpr cxx_noexcept
   )
 if (MMAPTWO_PLUS_OS GREATER -1)

--- a/mmaptwo.cpp
+++ b/mmaptwo.cpp
@@ -6,8 +6,9 @@
 #define MMAPTWO_PLUS_WIN32_DLL_INTERNAL
 #define _POSIX_C_SOURCE 200809L
 #include "mmaptwo.hpp"
-#include <cstdlib>
 #include <stdexcept>
+#include <new>
+#include <cstdlib>
 #include <cerrno>
 
 namespace mmaptwo {


### PR DESCRIPTION
Checks for `std::bad_alloc` require the `<new>` standard header file. Includes have also been reordered to better reflect inverse dependency ordering.

Closes #2.